### PR TITLE
Use the default cluster version

### DIFF
--- a/products/cloud/setup.sh
+++ b/products/cloud/setup.sh
@@ -62,7 +62,6 @@ gcloud beta container clusters create $PRODUCT_CLUSTER_NAME \
     --project $PROJECT_NAME \
     --zone $PROJECT_ZONE \
     --no-enable-basic-auth \
-    # --cluster-version "1.9.7-gke.3" \
     --machine-type "n1-standard-1" \
     --image-type "COS" \
     --disk-type "pd-standard" \

--- a/products/cloud/setup.sh
+++ b/products/cloud/setup.sh
@@ -62,7 +62,7 @@ gcloud beta container clusters create $PRODUCT_CLUSTER_NAME \
     --project $PROJECT_NAME \
     --zone $PROJECT_ZONE \
     --no-enable-basic-auth \
-    --cluster-version "1.9.7-gke.3" \
+    # --cluster-version "1.9.7-gke.3" \
     --machine-type "n1-standard-1" \
     --image-type "COS" \
     --disk-type "pd-standard" \


### PR DESCRIPTION
This script currently fails with the following error:

```
ERROR: (gcloud.beta.container.clusters.create) ResponseError: code=400, message=Master version "1.9.7-gke.
3" is unsupported.
```

I simply dropped the `--cluster-version` option to accept the default version.